### PR TITLE
Fix project dir variable when vendor not in project root

### DIFF
--- a/Internal/ComposerPlugin.php
+++ b/Internal/ComposerPlugin.php
@@ -93,7 +93,7 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
         if (!$nestingLevel) {
             $projectDir = '__'.'DIR__.'.var_export('/'.$projectDir, true);
         } else {
-            $projectDir = 'dirname(__'."DIR__, $nestingLevel)".('' !== $projectDir ? var_export('/'.$projectDir, true) : '');
+            $projectDir = 'dirname(__'."DIR__, $nestingLevel)".('' !== $projectDir ? '.'.var_export('/'.$projectDir, true) : '');
         }
 
         $runtimeClass = $extra['class'] ?? SymfonyRuntime::class;


### PR DESCRIPTION
A point is missing to concatenate the string.

Output example in the auto generated file "autoload_runtime.php" :

`'project_dir' => dirname(__DIR__, 1)'/html/')`

My vendor path is /var/www/vendor/ and my symfony project path is /var/www/html/.