### PR TITLE
Update ComposerPlugin.php

### DIFF
--- a/Internal/ComposerPlugin.php
+++ b/Internal/ComposerPlugin.php
@@ -58,7 +58,7 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
 
     public function updateAutoloadFile(): void
     {
-        $vendorDir = $this->composer->getConfig()->get('vendor-dir');
+        $vendorDir = realpath($this->composer->getConfig()->get('vendor-dir'));
 
         if (!is_file($autoloadFile = $vendorDir.'/autoload.php')
             || false === $extra = $this->composer->getPackage()->getExtra()['runtime'] ?? []


### PR DESCRIPTION
On Windows platforms, if the project is placed in a junction or symlink, `$this->composer->getConfig()->get('vendor-dir')` returns the junction path, but  `realpath(Factory::getComposerFile())` returns the junction target path. 

So if your project is at C:\www\fooProject ->{junction-to}-> D:\some-storage-directory\www\fooProj, the call to `$fs->makePathRelative()` tries to make relative paths across filesystems and you end up with a project directory of `C:\www\fooProject\\D:\some-storage-directory\www\fooProj` in your `vendor/autoload_runtime.php`.